### PR TITLE
Update cucumber enable spelling

### DIFF
--- a/switch2/payload.txt
+++ b/switch2/payload.txt
@@ -32,10 +32,12 @@ while [[ $SWITCH_POSITION = switch2 ]]; do
 	done
 done
 
+# Starting Blinking for Copy and Solid for DONE
+LED $i 100
 rm -rf /root/udisk/payloads/switch1/*
 cp -R /root/udisk/payloads/payload_${i}_*/* /root/udisk/payloads/switch1/
 
 echo "LED $i 100;sleep 2" > /tmp/tmp && cat /root/udisk/payloads/switch1/payload.txt >> /tmp/tmp && mv /tmp/tmp /root/udisk/payloads/switch1/payload.txt
 
 sync
-LED $i 100
+LED $i SOLID

--- a/switch2/payload.txt
+++ b/switch2/payload.txt
@@ -13,6 +13,9 @@
 
 #ATTACKMODE SERIAL ECM_ETHERNET # Uncomment for debugging purposes. Faster boot without.
 
+# Adding CPU Throttling to prevent overheating.
+CUCUMBER ENABLED
+
 targetPayload = 0
 i = 0
 
@@ -41,3 +44,13 @@ echo "LED $i 100;sleep 2" > /tmp/tmp && cat /root/udisk/payloads/switch1/payload
 
 sync
 LED $i SOLID
+
+# Adding Shutdown script with bonus "Wait 3 sec, blink twice and shutdown".
+sleep 3
+LED OFF
+LED $i SOLID
+LED OFF
+LED $i SOLID
+LED OFF
+LED $i SOLID
+shutdown 0

--- a/switch2/payload.txt
+++ b/switch2/payload.txt
@@ -14,7 +14,7 @@
 #ATTACKMODE SERIAL ECM_ETHERNET # Uncomment for debugging purposes. Faster boot without.
 
 # Adding CPU Throttling to prevent overheating.
-CUCUMBER ENABLED
+CUCUMBER ENABLE
 
 targetPayload = 0
 i = 0

--- a/switch2/payload.txt
+++ b/switch2/payload.txt
@@ -37,7 +37,8 @@ LED $i 100
 rm -rf /root/udisk/payloads/switch1/*
 cp -R /root/udisk/payloads/payload_${i}_*/* /root/udisk/payloads/switch1/
 
-echo "LED $i 100;sleep 2" > /tmp/tmp && cat /root/udisk/payloads/switch1/payload.txt >> /tmp/tmp && mv /tmp/tmp /root/udisk/payloads/switch1/payload.txt
+# Improved LED Indication on new payload. Adds to 2nd Line of Payload.
+sed -i "2i LED $i 100;sleep 2" /root/udisk/payloads/switch1/payload.txt
 
 sync
 LED $i SOLID


### PR DESCRIPTION
Corrected spelling on enable that was causing the payload to fail 